### PR TITLE
Add sentiment analysis feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ WhatsChat provides various features to analyze your chats, including:
 - _Emoji Analysis_: Shows the most frequently used emojis.
 - _Messages Extractor_: Extracts messages for a specific date.
 - _Reply Time Analysis_: Shows how much time each person takes to reply to a message.
+- _Sentiment Analysis_: Visualizes the proportion of positive, negative and neutral messages.
 
 You can perform all these analyses on group chats as well as individual chats.
 

--- a/app.py
+++ b/app.py
@@ -265,3 +265,23 @@ if uploadedFile is not None:
                 plt.style.use('dark_background')
                 ax.set_title('')
                 st.pyplot(fig)
+
+        # sentiment analysis
+        st.header("Sentiment Analysis😊")
+        pos, neg, neu = helper.sentimentAnalysis(selectedUser, dataFrame)
+        total = pos + neg + neu
+        if total == 0:
+            st.write("No text messages to analyze")
+        else:
+            col1, col2 = st.columns(2)
+            with col1:
+                fig, ax = plt.subplots()
+                labels = ['Positive', 'Negative', 'Neutral']
+                values = [pos, neg, neu]
+                ax.pie(values, labels=labels, autopct='%1.1f%%', colors=plt.cm.Pastel2.colors)
+                ax.axis('equal')
+                st.pyplot(fig)
+            with col2:
+                st.write('Positive:', pos)
+                st.write('Negative:', neg)
+                st.write('Neutral:', neu)

--- a/helper.py
+++ b/helper.py
@@ -6,6 +6,8 @@ import re
 import regex
 import streamlit as st
 from datetime import datetime
+from nltk.sentiment import SentimentIntensityAnalyzer
+import nltk
 
 
 def fetchStats(selectedUser, dataFrame):
@@ -158,3 +160,27 @@ def replyTime (selectedUser, x):
         timeSelected = timeDifference[timeDifference['user'] == selectedUser]['replyTime'].iloc[0]
 
     return timeDifference, timeSelected
+
+
+def sentimentAnalysis(selectedUser, x):
+    nltk.download('vader_lexicon', quiet=True)
+    sia = SentimentIntensityAnalyzer()
+    if selectedUser != "Overall":
+        x = x[x['user'] == selectedUser]
+
+    if x.empty:
+        return 0, 0, 0
+
+    def label_sentiment(msg):
+        score = sia.polarity_scores(str(msg))['compound']
+        if score >= 0.05:
+            return 'Positive'
+        if score <= -0.05:
+            return 'Negative'
+        return 'Neutral'
+
+    sentiments = x['message'].apply(label_sentiment)
+    positive = (sentiments == 'Positive').sum()
+    negative = (sentiments == 'Negative').sum()
+    neutral = (sentiments == 'Neutral').sum()
+    return positive, negative, neutral


### PR DESCRIPTION
## Summary
- add sentiment analysis to helper functions
- visualize message sentiment with pie chart in the app
- document new feature in README

## Testing
- `python -m py_compile helper.py app.py preprocessor.py`

------
https://chatgpt.com/codex/tasks/task_e_684295cc4fac832c81a199f2719bf33b